### PR TITLE
Update karma-jasmine-html-reporter version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "karma-chrome-launcher": "3.2.0",
     "karma-coverage": "2.2.1",
     "karma-jasmine": "5.1.0",
-    "karma-jasmine-html-reporter": "1.7.0",
+    "karma-jasmine-html-reporter": "2.1.0",
     "prettier": "3.1.1",
     "stylelint": "16.1.0",
     "stylelint-config-pretty-order": "0.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,8 +98,8 @@ devDependencies:
     specifier: 5.1.0
     version: 5.1.0(karma@6.4.2)
   karma-jasmine-html-reporter:
-    specifier: 1.7.0
-    version: 1.7.0(jasmine-core@5.1.1)(karma-jasmine@5.1.0)(karma@6.4.2)
+    specifier: 2.1.0
+    version: 2.1.0(jasmine-core@5.1.1)(karma-jasmine@5.1.0)(karma@6.4.2)
   prettier:
     specifier: 3.1.1
     version: 3.1.1
@@ -5468,12 +5468,12 @@ packages:
       - supports-color
     dev: true
 
-  /karma-jasmine-html-reporter@1.7.0(jasmine-core@5.1.1)(karma-jasmine@5.1.0)(karma@6.4.2):
-    resolution: {integrity: sha512-pzum1TL7j90DTE86eFt48/s12hqwQuiD+e5aXx2Dc9wDEn2LfGq6RoAxEZZjFiN0RDSCOnosEKRZWxbQ+iMpQQ==}
+  /karma-jasmine-html-reporter@2.1.0(jasmine-core@5.1.1)(karma-jasmine@5.1.0)(karma@6.4.2):
+    resolution: {integrity: sha512-sPQE1+nlsn6Hwb5t+HHwyy0A1FNCVKuL1192b+XNauMYWThz2kweiBVW1DqloRpVvZIJkIoHVB7XRpK78n1xbQ==}
     peerDependencies:
-      jasmine-core: '>=3.8'
-      karma: '>=0.9'
-      karma-jasmine: '>=1.1'
+      jasmine-core: ^4.0.0 || ^5.0.0
+      karma: ^6.0.0
+      karma-jasmine: ^5.0.0
     dependencies:
       jasmine-core: 5.1.1
       karma: 6.4.2


### PR DESCRIPTION
This pull request updates the version of karma-jasmine-html-reporter from 1.7.0 to 2.1.0. This update includes changes to the dependencies jasmine-core, karma, and karma-jasmine, ensuring compatibility with versions 4.0.0 and 5.0.0 of jasmine-core and version 6.0.0 of karma.